### PR TITLE
Pom with dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,3 +254,4 @@ idea {
 apply from: deps.scripts.jacoco
 apply from: deps.scripts.publish
 apply from: deps.scripts.repoLicenseReport
+apply from: deps.scripts.generatePom

--- a/money/src/main/java/io/spine/money/MoneyAmount.java
+++ b/money/src/main/java/io/spine/money/MoneyAmount.java
@@ -63,11 +63,11 @@ public final class MoneyAmount extends ValueHolder<Money> {
         checkNotNull(currency);
         checkValid(currency, units, nanos);
         Money amount = Money
-                .vBuilder()
+                .newBuilder()
                 .setCurrency(currency)
                 .setUnits(units)
                 .setNanos(nanos)
-                .build();
+                .vBuild();
         return new MoneyAmount(amount);
     }
 

--- a/money/src/test/java/io/spine/money/MoneyAmountTest.java
+++ b/money/src/test/java/io/spine/money/MoneyAmountTest.java
@@ -57,10 +57,10 @@ class MoneyAmountTest {
     @Test
     @DisplayName("create money amount holder out of money")
     void createOfMoney() {
-        Money money = Money.vBuilder()
+        Money money = Money.newBuilder()
                            .setCurrency(Currency.UAH)
                            .setUnits(1)
-                           .build();
+                           .vBuild();
         MoneyAmount amount = MoneyAmount.of(money);
         assertEquals(money.getCurrency(), amount.currency());
         assertEquals(money.getUnits(), amount.units());

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@ all modules and does not describe the project structure per-subproject.
  
  -->
 
+<groupId>io.spine</groupId>
 <artifactId>spine-money</artifactId>
 <version>1.0.0-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,58 +9,109 @@ This file is not suitable for `maven` build tasks. It only describes the first-l
 all modules and does not describe the project structure per-subproject.
  
  -->
+
+<artifactId>spine-money</artifactId>
+<version>1.0.0-SNAPSHOT</version>
+
+<inceptionYear>2015</inceptionYear>
+
 <licenses>
   <license>
     <name>Apache License, Version 2.0</name>
     <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     <distribution>repo</distribution>
   </license>
-</licenses><inceptionYear>2015</inceptionYear><artifactId>spine-money</artifactId>
-<version>1.0.0-SNAPSHOT</version><dependencies>
+</licenses>
+
+<dependencies>
   <dependency>
-    <groupId>io.spine</groupId>
-    <artifactId>spine-base</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-  </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-api</artifactId>
-    <version>5.4.2</version>
+    <groupId>com.google.code.findbugs</groupId>
+    <artifactId>jsr305</artifactId>
+    <version>3.0.2</version>
+    <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava</artifactId>
     <version>27.1-jre</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.protobuf</groupId>
-    <artifactId>protoc</artifactId>
-    <version>3.7.1</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.errorprone</groupId>
-    <artifactId>error_prone_core</artifactId>
-    <version>2.3.3</version>
-  </dependency>
-  <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-api</artifactId>
-    <version>1.7.26</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine</groupId>
-    <artifactId>spine-testlib</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java</artifactId>
     <version>3.7.1</version>
+    <scope>compile</scope>
   </dependency>
   <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-protoc-plugin</artifactId>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-java-util</artifactId>
+    <version>3.7.1</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine</groupId>
+    <artifactId>spine-base</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-api</artifactId>
+    <version>1.7.26</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava-testlib</artifactId>
+    <version>27.1-jre</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine</groupId>
+    <artifactId>spine-testlib</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.apiguardian</groupId>
+    <artifactId>apiguardian-api</artifactId>
+    <version>1.0.0</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.hamcrest</groupId>
+    <artifactId>hamcrest-all</artifactId>
+    <version>1.3</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-api</artifactId>
+    <version>5.4.2</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-engine</artifactId>
+    <version>5.4.2</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-params</artifactId>
+    <version>5.4.2</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-core</artifactId>
+    <version>2.12.0</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_core</artifactId>
+    <version>2.3.3</version>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
@@ -69,33 +120,8 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
-    <artifactId>protobuf-java-util</artifactId>
+    <artifactId>protoc</artifactId>
     <version>3.7.1</version>
-  </dependency>
-  <dependency>
-    <groupId>org.hamcrest</groupId>
-    <artifactId>hamcrest-all</artifactId>
-    <version>1.3</version>
-  </dependency>
-  <dependency>
-    <groupId>org.mockito</groupId>
-    <artifactId>mockito-core</artifactId>
-    <version>2.12.0</version>
-  </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-params</artifactId>
-    <version>5.4.2</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-errorprone-checks</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-  </dependency>
-  <dependency>
-    <groupId>org.apiguardian</groupId>
-    <artifactId>apiguardian-api</artifactId>
-    <version>1.0.0</version>
   </dependency>
   <dependency>
     <groupId>io.grpc</groupId>
@@ -103,9 +129,9 @@ all modules and does not describe the project structure per-subproject.
     <version>1.20.0</version>
   </dependency>
   <dependency>
-    <groupId>com.google.guava</groupId>
-    <artifactId>guava-testlib</artifactId>
-    <version>27.1-jre</version>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-errorprone-checks</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -113,13 +139,11 @@ all modules and does not describe the project structure per-subproject.
     <version>1.0.0-SNAPSHOT</version>
   </dependency>
   <dependency>
-    <groupId>com.google.code.findbugs</groupId>
-    <artifactId>jsr305</artifactId>
-    <version>3.0.2</version>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-protoc-plugin</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
   </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-engine</artifactId>
-    <version>5.4.2</version>
-  </dependency>
-</dependencies></project>
+</dependencies>
+</project>
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<modelVersion>4.0.0</modelVersion>
+
+<!-- 
+ 
+This file was generated using the Gradle `generatePom` task. 
+This file is not suitable for `maven` build tasks. It only describes the first-level dependencies of 
+all modules and does not describe the project structure per-subproject.
+ 
+ -->
+<licenses>
+  <license>
+    <name>Apache License, Version 2.0</name>
+    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    <distribution>repo</distribution>
+  </license>
+</licenses><inceptionYear>2015</inceptionYear><artifactId>spine-money</artifactId>
+<version>1.0.0-SNAPSHOT</version><dependencies>
+  <dependency>
+    <groupId>io.spine</groupId>
+    <artifactId>spine-base</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-api</artifactId>
+    <version>5.4.2</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava</artifactId>
+    <version>27.1-jre</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protoc</artifactId>
+    <version>3.7.1</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_core</artifactId>
+    <version>2.3.3</version>
+  </dependency>
+  <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-api</artifactId>
+    <version>1.7.26</version>
+  </dependency>
+  <dependency>
+    <groupId>io.spine</groupId>
+    <artifactId>spine-testlib</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-java</artifactId>
+    <version>3.7.1</version>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-protoc-plugin</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>javac</artifactId>
+    <version>9+181-r4173-1</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-java-util</artifactId>
+    <version>3.7.1</version>
+  </dependency>
+  <dependency>
+    <groupId>org.hamcrest</groupId>
+    <artifactId>hamcrest-all</artifactId>
+    <version>1.3</version>
+  </dependency>
+  <dependency>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-core</artifactId>
+    <version>2.12.0</version>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-params</artifactId>
+    <version>5.4.2</version>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-errorprone-checks</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apiguardian</groupId>
+    <artifactId>apiguardian-api</artifactId>
+    <version>1.0.0</version>
+  </dependency>
+  <dependency>
+    <groupId>io.grpc</groupId>
+    <artifactId>protoc-gen-grpc-java</artifactId>
+    <version>1.20.0</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava-testlib</artifactId>
+    <version>27.1-jre</version>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-javadoc-filter</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.code.findbugs</groupId>
+    <artifactId>jsr305</artifactId>
+    <version>3.0.2</version>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-engine</artifactId>
+    <version>5.4.2</version>
+  </dependency>
+</dependencies></project>


### PR DESCRIPTION
This PR updates the [https://github.com/SpineEventEngine/config](config) version, applies the `generatePom` task and adds the generated `pom.xml` file.

This PR also substitutes all usages of validating builders with regular builders and the `vBuild()` method.